### PR TITLE
add support for built-in security group

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.this_ingress_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.this_ingress_ipv6_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.this_ingress_prefix_list_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_timestreaminfluxdb_db_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/timestreaminfluxdb_db_instance) | resource |
+| [aws_subnet.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs
 
@@ -46,12 +51,15 @@ No modules.
 | <a name="input_db_instance_type"></a> [db\_instance\_type](#input\_db\_instance\_type) | The type of compute and memory capacity for the instance | `string` | `"db.influx.medium"` | no |
 | <a name="input_db_storage_type"></a> [db\_storage\_type](#input\_db\_storage\_type) | The storage type to be used (e.g., 'InfluxIOIncludedT1', 'InfluxIOIncludedT2', 'InfluxIOIncludedT3') | `string` | `null` | no |
 | <a name="input_deployment_type"></a> [deployment\_type](#input\_deployment\_type) | Deployment type, `SINGLE_AZ`, `WITH_MULTIAZ_STANDBY`, `MULTI_NODE_READ_REPLICAS`. | `string` | n/a | yes |
+| <a name="input_ingress_cidr_blocks"></a> [ingress\_cidr\_blocks](#input\_ingress\_cidr\_blocks) | List of security group ipv4 cidr blocks | `list(string)` | `[]` | no |
+| <a name="input_ingress_ipv6_cidr_blocks"></a> [ingress\_ipv6\_cidr\_blocks](#input\_ingress\_ipv6\_cidr\_blocks) | List of security group ipv6 cidr blocks | `list(string)` | `[]` | no |
+| <a name="input_ingress_prefix_list_ids"></a> [ingress\_prefix\_list\_ids](#input\_ingress\_prefix\_list\_ids) | List of security group prefix list ids | `list(string)` | `[]` | no |
 | <a name="input_log_delivery_configuration"></a> [log\_delivery\_configuration](#input\_log\_delivery\_configuration) | Configuration for sending InfluxDB engine logs to a specified S3 bucket. This argument is updatable. | <pre>object({<br/>    s3_configuration = object({<br/>      bucket_name = string<br/>      enabled     = bool<br/>    })<br/>  })</pre> | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Unique identifier name for the Timestream for InfluxDB instance or cluster | `string` | n/a | yes |
 | <a name="input_network_type"></a> [network\_type](#input\_network\_type) | Specifies whether the network type of the Timestream for InfluxDB cluster is IPV4, which can communicate over IPv4 protocol only, or DUAL, which can communicate over both IPv4 and IPv6 protocols. | `string` | `null` | no |
 | <a name="input_organization"></a> [organization](#input\_organization) | The organization name for InfluxDB | `string` | n/a | yes |
 | <a name="input_password"></a> [password](#input\_password) | Password for accessing the InfluxDB instance | `string` | n/a | yes |
-| <a name="input_port"></a> [port](#input\_port) | The port on which the cluster accepts connections. Valid values: `1024`-`65535`. Cannot be `2375`-`2376`, `7788`-`7799`, `8090`, or `51678`-`51680`. This argument is updatable. | `string` | `null` | no |
+| <a name="input_port"></a> [port](#input\_port) | The port on which the cluster/instance accepts connections. Valid values: `1024`-`65535`. Cannot be `2375`-`2376`, `7788`-`7799`, `8090`, or `51678`-`51680`. This argument is updatable. | `number` | `8086` | no |
 | <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Configures the DB instance/cluster with a public IP to facilitate access. Other resources, such as a VPC, a subnet, an internet gateway, and a route table with routes, are also required to enabled public access. | `bool` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to the resources | `map(string)` | `{}` | no |
 | <a name="input_username"></a> [username](#input\_username) | Username for accessing the InfluxDB instance | `string` | n/a | yes |

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,3 @@
+data "aws_subnet" "this" {
+  id = var.vpc_subnet_ids[0]
+}

--- a/examples/influxdb-instance/main.tf
+++ b/examples/influxdb-instance/main.tf
@@ -37,7 +37,7 @@ resource "aws_security_group" "influxdb_instance" {
 
 resource "aws_vpc_security_group_ingress_rule" "influxdb_instance" {
   security_group_id = aws_security_group.influxdb_instance.id
-  cidr_ipv4         = "0.0.0.0/0"
+  cidr_ipv4         = "172.31.0.0/16"
   ip_protocol       = "tcp"
   from_port         = 8086
   to_port           = 8086
@@ -62,8 +62,9 @@ module "influxdb_instance" {
 
   vpc_subnet_ids         = data.aws_subnets.all.ids
   vpc_security_group_ids = [aws_security_group.influxdb_instance.id]
+  ingress_cidr_blocks    = ["10.0.0.0/16"]
 
-  publicly_accessible = true
+  publicly_accessible = false
 
   log_delivery_configuration = {
     s3_configuration = {

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@
 
 #   publicly_accessible    = var.publicly_accessible
 #   vpc_subnet_ids         = var.vpc_subnet_ids
-#   vpc_security_group_ids = var.vpc_security_group_ids
+#   vpc_security_group_ids = concat([local.internal_security_group], var.vpc_security_group_ids)
 
 #   network_type = var.network_type
 #   port         = var.port
@@ -54,7 +54,7 @@ resource "aws_timestreaminfluxdb_db_instance" "this" {
 
   publicly_accessible    = var.publicly_accessible
   vpc_subnet_ids         = var.vpc_subnet_ids
-  vpc_security_group_ids = var.vpc_security_group_ids
+  vpc_security_group_ids = concat([local.internal_security_group], var.vpc_security_group_ids)
 
   network_type = var.network_type
   port         = var.port
@@ -70,4 +70,72 @@ resource "aws_timestreaminfluxdb_db_instance" "this" {
   }
 
   tags = var.tags
+}
+
+#####
+# Security group resources
+#####
+locals {
+  internal_security_group = try(aws_security_group.this[0].id, "")
+}
+
+resource "aws_security_group" "this" {
+  count = length(var.ingress_cidr_blocks) == 0 && length(var.ingress_ipv6_cidr_blocks) == 0 && length(var.ingress_prefix_list_ids) == 0 ? 0 : 1
+
+  name_prefix = "${var.name}-sg-"
+  description = "Timestream InfluxDB: ${var.name}"
+
+  vpc_id = data.aws_subnet.this.vpc_id
+
+  revoke_rules_on_delete = true
+
+  tags = merge(
+    {
+      "Name" = "${var.name}-sg"
+    },
+    var.tags
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "this_ingress_cidr_blocks" {
+  count = length(var.ingress_cidr_blocks) != 0 ? 1 : 0
+
+  description = "Allow Ingress ipv4 CIDR blocks."
+
+  type              = "ingress"
+  from_port         = var.port
+  to_port           = var.port
+  protocol          = "tcp"
+  cidr_blocks       = var.ingress_cidr_blocks
+  security_group_id = aws_security_group.this[0].id
+}
+
+resource "aws_security_group_rule" "this_ingress_ipv6_cidr_blocks" {
+  count = length(var.ingress_ipv6_cidr_blocks) != 0 ? 1 : 0
+
+  description = "Allow Ingress ipv6 CIDR blocks."
+
+  type              = "ingress"
+  from_port         = var.port
+  to_port           = var.port
+  protocol          = "tcp"
+  ipv6_cidr_blocks  = var.ingress_ipv6_cidr_blocks
+  security_group_id = aws_security_group.this[0].id
+}
+
+resource "aws_security_group_rule" "this_ingress_prefix_list_ids" {
+  count = length(var.ingress_prefix_list_ids) != 0 ? 1 : 0
+
+  description = "Allow Ingress prefix list ids."
+
+  type              = "ingress"
+  from_port         = var.port
+  to_port           = var.port
+  protocol          = "tcp"
+  prefix_list_ids   = var.ingress_prefix_list_ids
+  security_group_id = aws_security_group.this[0].id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,24 @@ variable "vpc_security_group_ids" {
   default     = []
 }
 
+variable "ingress_cidr_blocks" {
+  description = "List of security group ipv4 cidr blocks"
+  type        = list(string)
+  default     = []
+}
+
+variable "ingress_ipv6_cidr_blocks" {
+  description = "List of security group ipv6 cidr blocks"
+  type        = list(string)
+  default     = []
+}
+
+variable "ingress_prefix_list_ids" {
+  description = "List of security group prefix list ids"
+  type        = list(string)
+  default     = []
+}
+
 variable "deployment_type" {
   description = "Deployment type, `SINGLE_AZ`, `WITH_MULTIAZ_STANDBY`, `MULTI_NODE_READ_REPLICAS`."
   type        = string
@@ -90,9 +108,9 @@ variable "network_type" {
 }
 
 variable "port" {
-  description = "The port on which the cluster accepts connections. Valid values: `1024`-`65535`. Cannot be `2375`-`2376`, `7788`-`7799`, `8090`, or `51678`-`51680`. This argument is updatable."
-  type        = string
-  default     = null
+  description = "The port on which the cluster/instance accepts connections. Valid values: `1024`-`65535`. Cannot be `2375`-`2376`, `7788`-`7799`, `8090`, or `51678`-`51680`. This argument is updatable."
+  type        = number
+  default     = 8086
 }
 
 variable "tags" {


### PR DESCRIPTION
1. Add support for internal security group creation
2. support ipv4/ipv6 cidr blocks
3. support prefix lists
4. set default port
5. update example
6. update docs